### PR TITLE
Fix style of Validate and Parse

### DIFF
--- a/src/Parser/Parse.php
+++ b/src/Parser/Parse.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PsrJwt\Parser;
 

--- a/src/Validation/Validate.php
+++ b/src/Validation/Validate.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace PsrJwt\Validation;
 


### PR DESCRIPTION
@RobDWaller 
```
----------------------------------------------------------------------

FOUND 2 ERRORS AFFECTING 1 LINE

----------------------------------------------------------------------

 3 | ERROR | [x] Expected no space between directive and the equals

   |       |     sign in a declare statement

 3 | ERROR | [x] Expected no space between equal sign and the

   |       |     directive value in a declare statement

----------------------------------------------------------------------
```