### PR TITLE
2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.4', '8.0']
     name: PHP ${{ matrix.php-versions }} Test
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -11,22 +11,22 @@
         }
     ],
     "require": {
-        "php": ">=7.2.0",
-        "rbdwllr/reallysimplejwt": "^3.0",
+        "php": ">=7.4.0",
+        "rbdwllr/reallysimplejwt": "^4.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0",
-        "nyholm/psr7": "^1.2"
+        "nyholm/psr7": "^1.5"
     },
     "require-dev": {
-    	"phpunit/phpunit": "^8.0",
-        "phpstan/phpstan": "^0.11",
-        "phpstan/phpstan-mockery": "^0.11",
-        "phpmd/phpmd": "^2.7",
-        "squizlabs/php_codesniffer": "^3.0",
-        "mockery/mockery": "^1.3",
-        "infection/infection": "^0.14",
-        "phploc/phploc": "^5.0",
-        "sebastian/phpcpd": "^4.0"
+        "phpunit/phpunit": "^9.0",
+        "phpstan/phpstan": "^1.5",
+        "phpstan/phpstan-mockery": "^1.0",
+        "phpmd/phpmd": "^2.12",
+        "squizlabs/php_codesniffer": "^3.6",
+        "mockery/mockery": "^1.5",
+        "infection/infection": "^0.20",
+        "phploc/phploc": "^7.0",
+        "sebastian/phpcpd": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
             "vendor/bin/phpstan analyse -l 7 src/ tests/",
             "vendor/bin/phpmd src/ text ruleset.xml",
             "vendor/bin/phpunit --coverage-clover=coverage.xml",
-            "vendor/bin/infection -s --min-msi=89",
+            "vendor/bin/infection -s --min-msi=90",
             "vendor/bin/phpcpd --min-lines=2 --min-tokens=35 src/",
             "vendor/bin/phploc src/"
         ]

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
             "vendor/bin/phpstan analyse -l 7 src/ tests/",
             "vendor/bin/phpmd src/ text ruleset.xml",
             "vendor/bin/phpunit --coverage-clover=coverage.xml",
-            "vendor/bin/infection -s --min-msi=90",
+            "vendor/bin/infection -s --min-msi=89",
             "vendor/bin/phpcpd --min-lines=2 --min-tokens=35 src/",
             "vendor/bin/phploc src/"
         ]

--- a/src/Auth/Authorise.php
+++ b/src/Auth/Authorise.php
@@ -71,9 +71,9 @@ class Authorise
     {
         $jwt = new Jwt();
 
-        $parse = $jwt->parser($token, $this->secret);
+        $validator = $jwt->validator($token, $this->secret);
 
-        $validate = new Validate($parse);
+        $validate = new Validate($validator);
 
         $validationState = $validate->validate();
 

--- a/src/Factory/Jwt.php
+++ b/src/Factory/Jwt.php
@@ -4,12 +4,9 @@ declare(strict_types=1);
 
 namespace PsrJwt\Factory;
 
+use ReallySimpleJWT\Tokens;
 use ReallySimpleJWT\Build;
-use ReallySimpleJWT\Validate;
-use ReallySimpleJWT\Encode;
 use ReallySimpleJWT\Parse;
-use ReallySimpleJWT\Secret;
-use ReallySimpleJWT\Jwt as RSJwt;
 
 /**
  * PSR-JWT wraps around the ReallySimpleJWT library to provide token
@@ -26,12 +23,9 @@ class Jwt
      */
     public function builder(): Build
     {
-        return new Build(
-            'JWT',
-            new Validate(),
-            new Secret(),
-            new Encode()
-        );
+        $tokens = new Tokens();
+
+        return $tokens->builder();
     }
 
     /**
@@ -41,12 +35,8 @@ class Jwt
      */
     public function parser(string $token, string $secret): Parse
     {
-        $jwt = new RSJwt($token, $secret);
+        $tokens = new Tokens();
 
-        return new Parse(
-            $jwt,
-            new Validate(),
-            new Encode()
-        );
+        return $tokens->parser($token, $secret);
     }
 }

--- a/src/Factory/Jwt.php
+++ b/src/Factory/Jwt.php
@@ -30,7 +30,7 @@ class Jwt
     }
 
     /**
-     * Allow for the parsing and validation of JSON Web Tokens.
+     * Allow for the parsing of JSON Web Tokens.
      *
      * @return Parse
      */
@@ -41,6 +41,11 @@ class Jwt
         return $tokens->parser($token, $secret);
     }
 
+    /**
+     * Allow for the validation JSON Web Tokens.
+     *
+     * @return Validate
+     */
     public function validator(string $token, string $secret): Validate
     {
         $tokens = new Tokens();

--- a/src/Factory/Jwt.php
+++ b/src/Factory/Jwt.php
@@ -7,6 +7,7 @@ namespace PsrJwt\Factory;
 use ReallySimpleJWT\Tokens;
 use ReallySimpleJWT\Build;
 use ReallySimpleJWT\Parse;
+use ReallySimpleJWT\Validate;
 
 /**
  * PSR-JWT wraps around the ReallySimpleJWT library to provide token
@@ -38,5 +39,12 @@ class Jwt
         $tokens = new Tokens();
 
         return $tokens->parser($token, $secret);
+    }
+
+    public function validator(string $token, string $secret): Validate
+    {
+        $tokens = new Tokens();
+
+        return $tokens->validator($token, $secret);
     }
 }

--- a/src/Factory/JwtMiddleware.php
+++ b/src/Factory/JwtMiddleware.php
@@ -37,7 +37,7 @@ class JwtMiddleware
      *
      * @param string $tokenKey
      * @param string $secret
-     * @param array $body
+     * @param mixed[] $body
      * @return JwtAuthMiddleware
      */
     public static function json(string $secret, string $tokenKey = '', array $body = []): JwtAuthMiddleware

--- a/src/Handler/Json.php
+++ b/src/Handler/Json.php
@@ -18,14 +18,14 @@ use Nyholm\Psr7\Response;
 class Json extends Authorise implements RequestHandlerInterface
 {
     /**
-     * @var array The content to add to the response body.
+     * @var mixed[] The content to add to the response body.
      */
     private $body;
 
     /**
      * @param string $secret
      * @param string $tokenKey
-     * @param array $body
+     * @param mixed[] $body
      */
     public function __construct(string $secret, string $tokenKey, array $body)
     {

--- a/src/Helper/Request.php
+++ b/src/Helper/Request.php
@@ -33,7 +33,7 @@ class Request
 
     /**
      * Retrieve the JWT header information from a request.
-     * 
+     *
      * @return mixed[]
      */
     public function getTokenHeader(ServerRequestInterface $request, string $tokenKey): array
@@ -43,7 +43,7 @@ class Request
 
     /**
      * Retrieve the JWT payload information from a request.
-     * 
+     *
      * @return mixed[]
      */
     public function getTokenPayload(ServerRequestInterface $request, string $tokenKey): array

--- a/src/Helper/Request.php
+++ b/src/Helper/Request.php
@@ -33,6 +33,8 @@ class Request
 
     /**
      * Retrieve the JWT header information from a request.
+     * 
+     * @return mixed[]
      */
     public function getTokenHeader(ServerRequestInterface $request, string $tokenKey): array
     {
@@ -41,6 +43,8 @@ class Request
 
     /**
      * Retrieve the JWT payload information from a request.
+     * 
+     * @return mixed[]
      */
     public function getTokenPayload(ServerRequestInterface $request, string $tokenKey): array
     {

--- a/src/Parser/Parse.php
+++ b/src/Parser/Parse.php
@@ -13,7 +13,7 @@ use Psr\Http\Message\ServerRequestInterface;
 class Parse
 {
     /**
-     * @var array $parsers
+     * @var mixed[] $parsers
      */
     private $parsers = [];
 

--- a/src/Validation/Validate.php
+++ b/src/Validation/Validate.php
@@ -16,7 +16,7 @@ class Validate
     /**
      * @param Parse $parse
      */
-    private $parse;
+    private Parse $parse;
 
     /**
      * @param Parse $parse
@@ -29,7 +29,7 @@ class Validate
     /**
      * The JSON Web Token must be valid and not have expired.
      *
-     * @return array
+     * @return mixed[]
      */
     public function validate(): array
     {
@@ -48,7 +48,8 @@ class Validate
     /**
      * The token must be ready to use.
      *
-     * @return array
+     * @param mixed[] $validationState
+     * @return mixed[]
      */
     public function validateNotBefore(array $validationState): array
     {

--- a/src/Validation/Validate.php
+++ b/src/Validation/Validate.php
@@ -32,8 +32,8 @@ class Validate
     {
         try {
             $this->validate->structure()
-                ->expiration()
-                ->signature();
+                ->signature()
+                ->expiration();
         } catch (ValidateException $e) {
             if (in_array($e->getCode(), [1, 2, 3, 4], true)) {
                 return ['code' => $e->getCode(), 'message' => $e->getMessage()];

--- a/src/Validation/Validate.php
+++ b/src/Validation/Validate.php
@@ -32,7 +32,8 @@ class Validate
     {
         try {
             $this->validate->structure()
-                ->expiration();
+                ->expiration()
+                ->signature();
         } catch (ValidateException $e) {
             if (in_array($e->getCode(), [1, 2, 3, 4], true)) {
                 return ['code' => $e->getCode(), 'message' => $e->getMessage()];

--- a/src/Validation/Validate.php
+++ b/src/Validation/Validate.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace PsrJwt\Validation;
 
-use ReallySimpleJWT\Parse;
+use ReallySimpleJWT\Validate as RSValidate;
 use ReallySimpleJWT\Exception\ValidateException;
 
 /**
@@ -14,16 +14,13 @@ use ReallySimpleJWT\Exception\ValidateException;
 class Validate
 {
     /**
-     * @param Parse $parse
+     * @param RSValidate $validate
      */
-    private Parse $parse;
+    private RSValidate $validate;
 
-    /**
-     * @param Parse $parse
-     */
-    public function __construct(Parse $parse)
+    public function __construct(RSValidate $validate)
     {
-        $this->parse = $parse;
+        $this->validate = $validate;
     }
 
     /**
@@ -34,8 +31,8 @@ class Validate
     public function validate(): array
     {
         try {
-            $this->parse->validate()
-                ->validateExpiration();
+            $this->validate->structure()
+                ->expiration();
         } catch (ValidateException $e) {
             if (in_array($e->getCode(), [1, 2, 3, 4], true)) {
                 return ['code' => $e->getCode(), 'message' => $e->getMessage()];
@@ -54,7 +51,7 @@ class Validate
     public function validateNotBefore(array $validationState): array
     {
         try {
-            $this->parse->validateNotBefore();
+            $this->validate->notBefore();
         } catch (ValidateException $e) {
             if ($e->getCode()  === 5) {
                 return ['code' => $e->getCode(), 'message' => $e->getMessage()];

--- a/src/Validation/Validate.php
+++ b/src/Validation/Validate.php
@@ -6,6 +6,7 @@ namespace PsrJwt\Validation;
 
 use ReallySimpleJWT\Validate as RSValidate;
 use ReallySimpleJWT\Exception\ValidateException;
+use ReallySimpleJWT\Exception\ParseException;
 
 /**
  * Validate the JSON Web Token will parse, has a valid signature, is ready to
@@ -34,7 +35,7 @@ class Validate
             $this->validate->structure()
                 ->signature()
                 ->expiration();
-        } catch (ValidateException $e) {
+        } catch (ValidateException | ParseException $e) {
             if (in_array($e->getCode(), [1, 2, 3, 4], true)) {
                 return ['code' => $e->getCode(), 'message' => $e->getMessage()];
             }
@@ -53,7 +54,7 @@ class Validate
     {
         try {
             $this->validate->notBefore();
-        } catch (ValidateException $e) {
+        } catch (ValidateException | ParseException $e) {
             if ($e->getCode()  === 5) {
                 return ['code' => $e->getCode(), 'message' => $e->getMessage()];
             }

--- a/tests/Auth/AuthTest.php
+++ b/tests/Auth/AuthTest.php
@@ -10,7 +10,7 @@ class AuthTest extends TestCase
     /**
      * @covers PsrJwt\Auth\Auth::__construct
      */
-    public function testAuth()
+    public function testAuth(): Auth
     {
         $auth = new Auth(200, 'Ok');
         $this->assertInstanceOf(Auth::class, $auth);
@@ -21,7 +21,7 @@ class AuthTest extends TestCase
      * @depends testAuth
      * @covers PsrJwt\Auth\Auth::getCode
      */
-    public function testGetCode($auth)
+    public function testGetCode(Auth $auth): void
     {
         $this->assertSame(200, $auth->getCode());
     }
@@ -30,7 +30,7 @@ class AuthTest extends TestCase
      * @depends testAuth
      * @covers PsrJwt\Auth\Auth::getMessage
      */
-    public function testGetMessage($auth)
+    public function testGetMessage(Auth $auth): void
     {
         $this->assertSame('Ok', $auth->getMessage());
     }

--- a/tests/Auth/AuthoriseTest.php
+++ b/tests/Auth/AuthoriseTest.php
@@ -15,7 +15,7 @@ class AuthoriseTest extends TestCase
     /**
      * @covers PsrJwt\Auth\Authorise::__construct
      */
-    public function testAuthorise()
+    public function testAuthorise(): void
     {
         $auth = new Authorise('secret', 'jwt');
         $this->assertInstanceOf(Authorise::class, $auth);
@@ -34,7 +34,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Parser\Cookie
      * @uses PsrJwt\Parser\Request
      */
-    public function testAuthoriseOk()
+    public function testAuthoriseOk(): void
     {
         $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -81,7 +81,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Parser\Request
      * @uses PsrJwt\Parser\ParseException
      */
-    public function testAuthoriseBadRequest()
+    public function testAuthoriseBadRequest(): void
     {
         $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -116,7 +116,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Factory\Jwt
      * @uses PsrJwt\Validation\Validate
      */
-    public function testValidate()
+    public function testValidate(): void
     {
         $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -142,7 +142,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Factory\Jwt
      * @uses PsrJwt\Validation\Validate
      */
-    public function testValidateBadSecret()
+    public function testValidateBadSecret(): void
     {
         $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -168,7 +168,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Factory\Jwt
      * @uses PsrJwt\Validation\Validate
      */
-    public function testValidateBadExpiration()
+    public function testValidateBadExpiration(): void
     {
         $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -195,7 +195,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Factory\Jwt
      * @uses PsrJwt\Validation\Validate
      */
-    public function testValidateBadNotBefore()
+    public function testValidateBadNotBefore(): void
     {
         $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -220,7 +220,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Auth\Authorise::__construct
      * @uses PsrJwt\Auth\Auth
      */
-    public function testValidationResponse()
+    public function testValidationResponse(): void
     {
         $auth = new Authorise('secret', 'jwt');
 
@@ -238,7 +238,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Auth\Authorise::__construct
      * @uses PsrJwt\Auth\Auth
      */
-    public function testValidationResponseErrors()
+    public function testValidationResponseErrors(): void
     {
         $auth = new Authorise('secret', 'jwt');
 
@@ -272,7 +272,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Parser\Body
      * @uses PsrJwt\Parser\Request
      */
-    public function testGetToken()
+    public function testGetToken(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getHeader')
@@ -299,7 +299,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Parser\Query
      * @uses PsrJwt\Parser\Request
      */
-    public function testGetTokenCookie()
+    public function testGetTokenCookie(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getHeader')
@@ -329,7 +329,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Parser\Query
      * @uses PsrJwt\Parser\Request
      */
-    public function testGetTokenBody()
+    public function testGetTokenBody(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getHeader')
@@ -362,7 +362,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Parser\Query
      * @uses PsrJwt\Parser\Request
      */
-    public function testGetTokenBodyObject()
+    public function testGetTokenBodyObject(): void
     {
         $token = new \stdClass();
         $token->my_token = 'ghi.123.xyz';
@@ -398,7 +398,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Parser\Query
      * @uses PsrJwt\Parser\Request
      */
-    public function testGetTokenQuery()
+    public function testGetTokenQuery(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getHeader')
@@ -437,7 +437,7 @@ class AuthoriseTest extends TestCase
      * @uses PsrJwt\Parser\Request
      * @uses PsrJwt\Parser\ParseException
      */
-    public function testGetTokenNoToken()
+    public function testGetTokenNoToken(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getHeader')

--- a/tests/Auth/AuthoriseTest.php
+++ b/tests/Auth/AuthoriseTest.php
@@ -7,6 +7,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use PsrJwt\Auth\Authorise;
 use PsrJwt\Auth\Auth;
 use PsrJwt\Factory\Jwt;
+use PsrJwt\Parser\ParseException;
 use ReflectionMethod;
 use Mockery as m;
 
@@ -425,8 +426,6 @@ class AuthoriseTest extends TestCase
     }
 
     /**
-     * @expectedException PsrJwt\Parser\ParseException
-     * @expectedExceptionMessage JSON Web Token not set in request.
      * @covers PsrJwt\Auth\Authorise::getToken
      * @uses PsrJwt\Auth\Authorise
      * @uses PsrJwt\Parser\Parse
@@ -458,7 +457,9 @@ class AuthoriseTest extends TestCase
 
         $method = new ReflectionMethod(Authorise::class, 'getToken');
         $method->setAccessible(true);
-        $result = $method->invokeArgs($auth, [$request]);
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage("JSON Web Token not set in request.");
+        $method->invokeArgs($auth, [$request]);
     }
 
     public function tearDown(): void

--- a/tests/Factory/JwtMiddlewareTest.php
+++ b/tests/Factory/JwtMiddlewareTest.php
@@ -20,7 +20,7 @@ class JwtMiddlewareTest extends TestCase
      * @uses PsrJwt\Auth\Authorise
      * @uses PsrJwt\Handler\Html
      */
-    public function testJwtMiddlewareHtml()
+    public function testJwtMiddlewareHtml(): void
     {
         $this->assertInstanceOf(
             JwtAuthMiddleware::class,
@@ -44,7 +44,7 @@ class JwtMiddlewareTest extends TestCase
      * @uses PsrJwt\Parser\Query
      * @uses PsrJwt\Parser\Request
      */
-    public function testFactoryValidation()
+    public function testFactoryValidation(): void
     {
         $jwt = $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -90,7 +90,7 @@ class JwtMiddlewareTest extends TestCase
      * @uses PsrJwt\Parser\Query
      * @uses PsrJwt\Parser\Request
      */
-    public function testJsonFactoryValidation()
+    public function testJsonFactoryValidation(): void
     {
         $jwt = $jwt = new Jwt();
         $jwt = $jwt->builder();

--- a/tests/Factory/JwtTest.php
+++ b/tests/Factory/JwtTest.php
@@ -12,7 +12,7 @@ class JwtTest extends TestCase
     /**
      * @covers PsrJwt\Factory\Jwt::builder
      */
-    public function testJwtBuilder()
+    public function testJwtBuilder(): void
     {
         $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -23,7 +23,7 @@ class JwtTest extends TestCase
     /**
      * @covers PsrJwt\Factory\Jwt::parser
      */
-    public function testJwtParser()
+    public function testJwtParser(): void
     {
         $jwt = new Jwt();
         $jwt = $jwt->parser('aaa.bbb.ccc', 'secret');

--- a/tests/Factory/JwtTest.php
+++ b/tests/Factory/JwtTest.php
@@ -5,6 +5,7 @@ namespace Tests\Factory;
 use PHPUnit\Framework\TestCase;
 use ReallySimpleJWT\Build;
 use ReallySimpleJWT\Parse;
+use ReallySimpleJWT\Validate;
 use PsrJwt\Factory\Jwt;
 
 class JwtTest extends TestCase
@@ -29,5 +30,16 @@ class JwtTest extends TestCase
         $jwt = $jwt->parser('aaa.bbb.ccc', 'secret');
 
         $this->assertInstanceOf(Parse::class, $jwt);
+    }
+
+    /**
+     * @covers PsrJwt\Factory\Jwt::validator
+     */
+    public function testJwtValidator(): void
+    {
+        $jwt = new Jwt();
+        $jwt = $jwt->validator('aaa.bbb.ccc', 'secret');
+
+        $this->assertInstanceOf(Validate::class, $jwt);
     }
 }

--- a/tests/Handler/HtmlTest.php
+++ b/tests/Handler/HtmlTest.php
@@ -17,7 +17,7 @@ class HtmlTest extends TestCase
      * @covers PsrJwt\Handler\Html::__construct
      * @uses PsrJwt\Auth\Authorise
      */
-    public function testAuthHandler()
+    public function testAuthHandler(): void
     {
         $auth = new Html('secret', 'tokenKey', 'body');
 
@@ -40,7 +40,7 @@ class HtmlTest extends TestCase
      * @uses PsrJwt\Parser\Parse
      * @uses PsrJwt\Parser\Request
      */
-    public function testAuthoriseOk()
+    public function testAuthoriseOk(): void
     {
         $jwt = $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -89,7 +89,7 @@ class HtmlTest extends TestCase
      * @uses PsrJwt\Parser\Parse
      * @uses PsrJwt\Parser\Request
      */
-    public function testAuthoriseNoBody()
+    public function testAuthoriseNoBody(): void
     {
         $jwt = $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -138,7 +138,7 @@ class HtmlTest extends TestCase
      * @uses PsrJwt\Parser\Request
      * @uses PsrJwt\Parser\ParseException
      */
-    public function testAuthoriseBadRequest()
+    public function testAuthoriseBadRequest(): void
     {
         $jwt = $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -186,7 +186,7 @@ class HtmlTest extends TestCase
      * @uses PsrJwt\Parser\Parse
      * @uses PsrJwt\Parser\Request
      */
-    public function testAuthoriseUnauthorized()
+    public function testAuthoriseUnauthorized(): void
     {
         $jwt = $jwt = new Jwt();
         $jwt = $jwt->builder();

--- a/tests/Handler/JsonTest.php
+++ b/tests/Handler/JsonTest.php
@@ -17,7 +17,7 @@ class JsonTest extends TestCase
      * @covers PsrJwt\Handler\Json::__construct
      * @uses PsrJwt\Auth\Authorise
      */
-    public function testJsonAuthHandler()
+    public function testJsonAuthHandler(): void
     {
         $auth = new Json('secret', 'tokenKey', ['body']);
 
@@ -41,7 +41,7 @@ class JsonTest extends TestCase
      * @uses PsrJwt\Parser\Bearer
      * @uses PsrJwt\Parser\Request
      */
-    public function testAuthoriseOk()
+    public function testAuthoriseOk(): void
     {
         $jwt = $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -90,7 +90,7 @@ class JsonTest extends TestCase
      * @uses PsrJwt\Parser\Parse
      * @uses PsrJwt\Parser\Request
      */
-    public function testAuthoriseFail()
+    public function testAuthoriseFail(): void
     {
         $jwt = $jwt = new Jwt();
         $jwt = $jwt->builder();

--- a/tests/Handler/JsonTest.php
+++ b/tests/Handler/JsonTest.php
@@ -46,6 +46,8 @@ class JsonTest extends TestCase
         $jwt = $jwt = new Jwt();
         $jwt = $jwt->builder();
         $token = $jwt->setSecret('Secret123!456$')
+            ->setExpiration(time() + 10)
+            ->setNotBefore(time() - 10)
             ->setIssuer('localhost')
             ->build()
             ->getToken();
@@ -95,6 +97,8 @@ class JsonTest extends TestCase
         $jwt = $jwt = new Jwt();
         $jwt = $jwt->builder();
         $token = $jwt->setSecret('Secret123!456$')
+            ->setExpiration(time() + 10)
+            ->setNotBefore(time() - 10)
             ->setIssuer('localhost')
             ->build()
             ->getToken();

--- a/tests/Helper/RequestTest.php
+++ b/tests/Helper/RequestTest.php
@@ -19,7 +19,7 @@ class RequestTest extends TestCase
     /**
      * @covers PsrJwt\Helper\Request
      */
-    public function testRequest()
+    public function testRequest(): void
     {
         $request = new Request();
 
@@ -36,7 +36,7 @@ class RequestTest extends TestCase
      * @uses PsrJwt\Parser\Query
      * @uses PsrJwt\Parser\Request
      */
-    public function testGetParsedToken()
+    public function testGetParsedToken(): void
     {
         $httpRequest = m::mock(ServerRequestInterface::class);
         $httpRequest->shouldReceive('getHeader')
@@ -62,7 +62,7 @@ class RequestTest extends TestCase
      * @uses PsrJwt\Parser\Query
      * @uses PsrJwt\Parser\Request
      */
-    public function testGetTokenHeader()
+    public function testGetTokenHeader(): void
     {
         $httpRequest = m::mock(ServerRequestInterface::class);
         $httpRequest->shouldReceive('getHeader')
@@ -88,7 +88,7 @@ class RequestTest extends TestCase
      * @uses PsrJwt\Parser\Query
      * @uses PsrJwt\Parser\Request
      */
-    public function testGetTokenPayload()
+    public function testGetTokenPayload(): void
     {
         $httpRequest = m::mock(ServerRequestInterface::class);
         $httpRequest->shouldReceive('getHeader')

--- a/tests/JwtAuthMiddlewareTest.php
+++ b/tests/JwtAuthMiddlewareTest.php
@@ -21,7 +21,7 @@ class JwtAuthMiddlewareTest extends TestCase
      * @uses PsrJwt\Auth\Authorise
      * @uses PsrJwt\Handler\Html
      */
-    public function testJwtAuthProcess()
+    public function testJwtAuthProcess(): void
     {
         $authorise = new Html('secret', 'jwt', '');
 
@@ -46,7 +46,7 @@ class JwtAuthMiddlewareTest extends TestCase
      * @uses PsrJwt\Parser\Query
      * @uses PsrJwt\Parser\Request
      */
-    public function testProcess()
+    public function testProcess(): void
     {
         $jwt = $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -97,7 +97,7 @@ class JwtAuthMiddlewareTest extends TestCase
      * @uses PsrJwt\Parser\Request
      * @uses PsrJwt\Parser\ParseException
      */
-    public function testProcessFail()
+    public function testProcessFail(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getCookieParams')
@@ -143,7 +143,7 @@ class JwtAuthMiddlewareTest extends TestCase
      * @uses PsrJwt\Parser\Request
      * @uses PsrJwt\Handler\Html
      */
-    public function testInvoke()
+    public function testInvoke(): void
     {
         $jwt = new Jwt();
         $jwt = $jwt->builder();
@@ -197,7 +197,7 @@ class JwtAuthMiddlewareTest extends TestCase
      * @uses PsrJwt\Handler\Html
      * @uses PsrJwt\Parser\Request
      */
-    public function testInvokeFail()
+    public function testInvokeFail(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getCookieParams')

--- a/tests/Parser/BearerTest.php
+++ b/tests/Parser/BearerTest.php
@@ -13,7 +13,7 @@ class BearerTest extends TestCase
     /**
      * @covers PsrJwt\Parser\Bearer
      */
-    public function testBearer()
+    public function testBearer(): void
     {
         $bearer = new Bearer();
 
@@ -24,7 +24,7 @@ class BearerTest extends TestCase
     /**
      * @covers PsrJwt\Parser\Bearer::parse
      */
-    public function testParse()
+    public function testParse(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getHeader')
@@ -41,7 +41,7 @@ class BearerTest extends TestCase
     /**
      * @covers PsrJwt\Parser\Bearer::parse
      */
-    public function testParseInvalid()
+    public function testParseInvalid(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getHeader')

--- a/tests/Parser/BodyTest.php
+++ b/tests/Parser/BodyTest.php
@@ -14,7 +14,7 @@ class BodyTest extends TestCase
     /**
      * @covers PsrJwt\Parser\Body::__construct
      */
-    public function testBody()
+    public function testBody(): void
     {
         $body = new Body('jwt');
 
@@ -26,7 +26,7 @@ class BodyTest extends TestCase
      * @covers PsrJwt\Parser\Body::parse
      * @uses PsrJwt\Parser\Body::__construct
      */
-    public function testParse()
+    public function testParse(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getParsedBody')
@@ -43,7 +43,7 @@ class BodyTest extends TestCase
      * @covers PsrJwt\Parser\Body::parse
      * @uses PsrJwt\Parser\Body
      */
-    public function testParseObject()
+    public function testParseObject(): void
     {
         $object = new \stdClass();
         $object->jwt = 'abc.def.ghi';
@@ -63,7 +63,7 @@ class BodyTest extends TestCase
      * @covers PsrJwt\Parser\Body::parse
      * @uses PsrJwt\Parser\Body
      */
-    public function testParseString()
+    public function testParseString(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getParsedBody')
@@ -80,7 +80,7 @@ class BodyTest extends TestCase
      * @covers PsrJwt\Parser\Body::parseBodyObject
      * @uses PsrJwt\Parser\Body::__construct
      */
-    public function testParseBodyObject()
+    public function testParseBodyObject(): void
     {
         $object = new \stdClass();
         $object->jwt = 'abc.def.ghi';
@@ -103,7 +103,7 @@ class BodyTest extends TestCase
      * @covers PsrJwt\Parser\Body::parseBodyObject
      * @uses PsrJwt\Parser\Body::__construct
      */
-    public function testParseBodyObjectNoKey()
+    public function testParseBodyObjectNoKey(): void
     {
         $object = new \stdClass();
 
@@ -125,7 +125,7 @@ class BodyTest extends TestCase
      * @covers PsrJwt\Parser\Body::parseBodyObject
      * @uses PsrJwt\Parser\Body::__construct
      */
-    public function testParseBodyObjectNoObject()
+    public function testParseBodyObjectNoObject(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getParsedBody')

--- a/tests/Parser/CookieTest.php
+++ b/tests/Parser/CookieTest.php
@@ -13,7 +13,7 @@ class CookieTest extends TestCase
     /**
      * @covers PsrJwt\Parser\Cookie::__construct
      */
-    public function testCookie()
+    public function testCookie(): void
     {
         $cookie = new Cookie('jwt');
 
@@ -25,7 +25,7 @@ class CookieTest extends TestCase
      * @covers PsrJwt\Parser\Cookie::parse
      * @uses PsrJwt\Parser\Cookie::__construct
      */
-    public function testParse()
+    public function testParse(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getCookieParams')

--- a/tests/Parser/ParseExceptionTest.php
+++ b/tests/Parser/ParseExceptionTest.php
@@ -11,7 +11,7 @@ class ParseExceptionTest extends TestCase
     /**
      * @covers PsrJwt\Parser\ParseException
      */
-    public function testParseException()
+    public function testParseException(): void
     {
         $exception = new ParseException('Error', 1, null);
 

--- a/tests/Parser/ParseTest.php
+++ b/tests/Parser/ParseTest.php
@@ -18,7 +18,7 @@ class ParseTest extends TestCase
     /**
      * @covers PsrJwt\Parser\Parse
      */
-    public function testParse()
+    public function testParse(): void
     {
         $parse = new Parse();
         $this->assertInstanceOf(Parse::class, $parse);
@@ -30,7 +30,7 @@ class ParseTest extends TestCase
      * @uses PsrJwt\Parser\Parse
      * @uses PsrJwt\Parser\Bearer
      */
-    public function testFindToken()
+    public function testFindToken(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getHeader')
@@ -54,7 +54,7 @@ class ParseTest extends TestCase
      * @uses PsrJwt\Parser\Body
      * @uses PsrJwt\Parser\Query
      */
-    public function testFindTokenMultiParser()
+    public function testFindTokenMultiParser(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getHeader')
@@ -79,7 +79,7 @@ class ParseTest extends TestCase
      * @covers PsrJwt\Parser\Parse::findToken
      * @uses PsrJwt\Parser\Parse
      */
-    public function testFindTokenFail()
+    public function testFindTokenFail(): void
     {
         $request = m::mock(ServerRequestInterface::class);
 

--- a/tests/Parser/QueryTest.php
+++ b/tests/Parser/QueryTest.php
@@ -13,7 +13,7 @@ class QueryTest extends TestCase
     /**
      * @covers PsrJwt\Parser\Query::__construct
      */
-    public function testQuery()
+    public function testQuery(): void
     {
         $query = new Query('jwt');
 
@@ -25,7 +25,7 @@ class QueryTest extends TestCase
      * @covers PsrJwt\Parser\Query::parse
      * @uses PsrJwt\Parser\Query::__construct
      */
-    public function testParse()
+    public function testParse(): void
     {
         $request = m::mock(ServerRequestInterface::class);
         $request->shouldReceive('getQueryParams')

--- a/tests/Parser/RequestTest.php
+++ b/tests/Parser/RequestTest.php
@@ -14,7 +14,7 @@ class RequestTest extends TestCase
      * @covers PsrJwt\Parser\Request
      * @uses PsrJwt\Parser\Parse
      */
-    public function testRequest()
+    public function testRequest(): void
     {
         $parse = new Parse();
 
@@ -31,7 +31,7 @@ class RequestTest extends TestCase
      * @uses PsrJwt\Parser\Body
      * @uses PsrJwt\Parser\Query
      */
-    public function testParse()
+    public function testParse(): void
     {
         $parse = m::mock(Parse::class);
         $parse->shouldReceive('addParser')
@@ -57,7 +57,7 @@ class RequestTest extends TestCase
      * @uses PsrJwt\Parser\Query
      * @uses PsrJwt\Parser\ParseException
      */
-    public function testParseNoToken()
+    public function testParseNoToken(): void
     {
         $parse = m::mock(Parse::class);
         $parse->shouldReceive('addParser')

--- a/tests/Parser/RequestTest.php
+++ b/tests/Parser/RequestTest.php
@@ -36,7 +36,7 @@ class RequestTest extends TestCase
         $parse = m::mock(Parse::class);
         $parse->shouldReceive('addParser')
             ->times(4);
-            
+
         $parse->shouldReceive('findToken')
             ->once()
             ->andReturn('abcdef.123.abcdef');
@@ -62,7 +62,7 @@ class RequestTest extends TestCase
         $parse = m::mock(Parse::class);
         $parse->shouldReceive('addParser')
             ->times(4);
-            
+
         $parse->shouldReceive('findToken')
             ->once()
             ->andReturn('');

--- a/tests/Validation/ValidateTest.php
+++ b/tests/Validation/ValidateTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Validation;
 
 use PHPUnit\Framework\TestCase;
-use ReallySimpleJWT\Parse;
+use ReallySimpleJWT\Validate as RSValidate;
 use PsrJwt\Factory\Jwt;
 use PsrJwt\Validation\Validate;
 
@@ -24,7 +24,7 @@ class ValidateTest extends TestCase
             ->getToken();
 
         $validate = new Validate(
-            $jwt->parser($token, 'Secret123!456$')
+            $jwt->validator($token, 'Secret123!456$')
         );
 
         $this->assertInstanceOf(Validate::class, $validate);
@@ -46,7 +46,7 @@ class ValidateTest extends TestCase
             ->getToken();
 
         $validate = new Validate(
-            $jwt->parser($token, 'Secret123!456$')
+            $jwt->validator($token, 'Secret123!456$')
         );
 
         $result = $validate->validate();
@@ -71,7 +71,7 @@ class ValidateTest extends TestCase
             ->getToken();
 
         $validate = new Validate(
-            $jwt->parser($token, 'Secret123!456$')
+            $jwt->validator($token, 'Secret123!456$')
         );
 
         $result = $validate->validate();
@@ -83,14 +83,14 @@ class ValidateTest extends TestCase
     /**
      * @covers PsrJwt\Validation\Validate::validate
      * @uses PsrJwt\Validation\Validate
-     * @uses PsrJwt\Factory\Jwt::parser
+     * @uses PsrJwt\Factory\Jwt::validator
      */
     public function testValidateTokenStructure(): void
     {
         $jwt = new Jwt();
 
         $validate = new Validate(
-            $jwt->parser('123.abc', 'Secret123!456$')
+            $jwt->validator('123.abc', 'Secret123!456$')
         );
 
         $result = $validate->validate();
@@ -102,14 +102,14 @@ class ValidateTest extends TestCase
     /**
      * @covers PsrJwt\Validation\Validate::validate
      * @uses PsrJwt\Validation\Validate
-     * @uses PsrJwt\Factory\Jwt::parser
+     * @uses PsrJwt\Factory\Jwt::validator
      */
     public function testValidateBadSignature(): void
     {
         $jwt = new Jwt();
 
         $validate = new Validate(
-            $jwt->parser('123.abc.456', 'Secret123!456$')
+            $jwt->validator('123.abc.456', 'Secret123!456$')
         );
 
         $result = $validate->validate();
@@ -134,7 +134,7 @@ class ValidateTest extends TestCase
             ->getToken();
 
         $validate = new Validate(
-            $jwt->parser($token, 'Secret123!456$')
+            $jwt->validator($token, 'Secret123!456$')
         );
 
         $result = $validate->validateNotBefore(
@@ -161,7 +161,7 @@ class ValidateTest extends TestCase
             ->getToken();
 
         $validate = new Validate(
-            $jwt->parser($token, 'Secret123!456$')
+            $jwt->validator($token, 'Secret123!456$')
         );
 
         $result = $validate->validateNotBefore(

--- a/tests/Validation/ValidateTest.php
+++ b/tests/Validation/ValidateTest.php
@@ -13,7 +13,7 @@ class ValidateTest extends TestCase
      * @covers PsrJwt\Validation\Validate::__construct
      * @uses PsrJwt\Factory\Jwt
      */
-    public function testValidate()
+    public function testValidate(): void
     {
         $jwt = new Jwt();
         $builder = $jwt->builder();
@@ -35,7 +35,7 @@ class ValidateTest extends TestCase
      * @uses PsrJwt\Validation\Validate
      * @uses PsrJwt\Factory\Jwt
      */
-    public function testValidateOk()
+    public function testValidateOk(): void
     {
         $jwt = new Jwt();
         $builder = $jwt->builder();
@@ -60,7 +60,7 @@ class ValidateTest extends TestCase
      * @uses PsrJwt\Validation\Validate
      * @uses PsrJwt\Factory\Jwt
      */
-    public function testValidateExpiration()
+    public function testValidateExpiration(): void
     {
         $jwt = new Jwt();
         $builder = $jwt->builder();
@@ -85,7 +85,7 @@ class ValidateTest extends TestCase
      * @uses PsrJwt\Validation\Validate
      * @uses PsrJwt\Factory\Jwt::parser
      */
-    public function testValidateTokenStructure()
+    public function testValidateTokenStructure(): void
     {
         $jwt = new Jwt();
 
@@ -104,7 +104,7 @@ class ValidateTest extends TestCase
      * @uses PsrJwt\Validation\Validate
      * @uses PsrJwt\Factory\Jwt::parser
      */
-    public function testValidateBadSignature()
+    public function testValidateBadSignature(): void
     {
         $jwt = new Jwt();
 
@@ -123,7 +123,7 @@ class ValidateTest extends TestCase
      * @uses PsrJwt\Validation\Validate
      * @uses PsrJwt\Factory\Jwt
      */
-    public function testValidateNotBefore()
+    public function testValidateNotBefore(): void
     {
         $jwt = new Jwt();
         $builder = $jwt->builder();
@@ -150,7 +150,7 @@ class ValidateTest extends TestCase
      * @uses PsrJwt\Validation\Validate
      * @uses PsrJwt\Factory\Jwt
      */
-    public function testValidateNotBeforeOk()
+    public function testValidateNotBeforeOk(): void
     {
         $jwt = new Jwt();
         $builder = $jwt->builder();


### PR DESCRIPTION
- Upgraded to PHP 7.4.
- Upgraded dependent libraries to support PHP 7.4
- Upgraded to ReallySimpleJWT version 4.0.
- Applied fixes to work with ReallySimpleJWT version 4.0.
- Made use of the Tokens factory class available in ReallySimpleJWT version 4.0.
- Applied type fixes to Tests and resolved other issues highlighted by PHPStan.