### PR TITLE
Add Composer's allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,10 @@
             "vendor/bin/phpcpd --min-lines=2 --min-tokens=35 src/",
             "vendor/bin/phploc src/"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "infection/extension-installer": true
+        }
     }
 }


### PR DESCRIPTION
CI already says

> For additional security you should declare the allow-plugins config with a list of packages names that are allowed to run code. See getcomposer.org/allow-plugins
> You have until July 2022 to add the setting. Composer will then switch the default behavior to disallow all plugins.
