### PR TITLE
Fix package installation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       run: composer validate --strict
 
     - name: Install Composer Dependencies 
-      run: composer install --no-interaction --prefer-source
+      run: composer update --no-interaction --prefer-source
     
     - name: Run Tests
       run: composer pipeline


### PR DESCRIPTION
We do not have a lock file.

> No composer.lock file present. Updating dependencies to latest instead of installing from lock file. See [getcomposer.org/install](https://getcomposer.org/install) for more information.
